### PR TITLE
[bugfix]解决因数据库名为中文而导致的连接创建失败

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 *env/*
 .DS_Store
 .idea
+*.swp

--- a/pgdb/pgdb.py
+++ b/pgdb/pgdb.py
@@ -7,6 +7,9 @@ import psycopg2
 from psycopg2 import extensions as _ext
 
 class PgdbError(Exception):
+    """
+        Pgdb自定义错误类型。直接传入字符串作为提示
+    """
     def __init__(self, value):
         self.value = value
     def __str__(self):
@@ -53,6 +56,9 @@ class Connection:
         self._close()
 
     def ensure_connected(self):
+        """
+            确认数据库连接有效
+        """
         try:
             cursor = self.connection.cursor()
         except Exception as e:
@@ -65,6 +71,9 @@ class Connection:
         return cursor
 
     def _get_dsn(self):
+        """
+            自行拼接生成用于初始化数据库连接的 dsn 字符串
+        """
         may_dbname = self.db_kwargs.get('dbname', -1)
         may_database = self.db_kwargs.get('database', -1)
         if (may_dbname != -1) and may_database:  # 若提供了两个数据库名
@@ -78,6 +87,9 @@ class Connection:
         return dsn
 
     def _reconnect(self):
+        """
+            创建数据库连接
+        """
         self._close()
         try:
             self.connection = psycopg2.connect(*self.db_args, **self.db_kwargs)
@@ -90,6 +102,9 @@ class Connection:
         self.autocommit = True
 
     def query(self, *args, **kwargs):
+        """
+            查询多条记录
+        """
         cursor = self._cursor()
         try:
             cursor.execute(*args, **kwargs)
@@ -106,6 +121,9 @@ class Connection:
                 raise e
 
     def get(self, *args, **kwargs):
+        """
+            查询一条记录
+        """
         res = self.query(*args, **kwargs)
         if not res:
             return None
@@ -115,6 +133,9 @@ class Connection:
             return res[0]
 
     def execute(self, *args, **kwargs):
+        """
+            执行一条语句
+        """
         cursor = self._cursor()
         try:
             cursor.execute(*args, **kwargs)
@@ -127,6 +148,9 @@ class Connection:
                 raise e
 
     def executemany(self, *args, **kwargs):
+        """
+            执行多条语句
+        """
         cursor = self._cursor()
         try:
             cursor.executemany(*args, **kwargs)

--- a/pgdb/pgdb.py
+++ b/pgdb/pgdb.py
@@ -74,13 +74,12 @@ class Connection:
         """
             自行拼接生成用于初始化数据库连接的 dsn 字符串
         """
-        may_dbname = self.db_kwargs.get('dbname', -1)
-        may_database = self.db_kwargs.get('database', -1)
-        if (may_dbname != -1) and may_database:  # 若提供了两个数据库名
-            raise PgdbError('Name confused: {} or {}?'.format(may_dbname, may_database))
-        elif (may_dbname == -1) and (may_database == -1):
-            raise PgdbError('Should provide the database name to keyword "database" or "dbname"')
-        dbname = may_dbname if may_dbname != -1 else may_database
+        may_dbname = self.db_kwargs.get('dbname', '')
+        may_database = self.db_kwargs.get('database', '')
+
+        # 不会出现同时有值的情况：那样会在 try 时报 TypeError 而不会进到该函数
+        # 也不会同时没值：那样通常会报 psycopg2.OperationalError，也不会进到该函数
+        dbname = may_dbname or may_database
         self.db_kwargs.pop('dbname', None)
         self.db_kwargs.pop('database', None)
         dsn = psycopg2.extensions.make_dsn(*self.db_args, **self.db_kwargs) + " dbname='%s'" % dbname

--- a/pgdb/pgdb.py
+++ b/pgdb/pgdb.py
@@ -82,7 +82,14 @@ class Connection:
         dbname = may_dbname or may_database
         self.db_kwargs.pop('dbname', None)
         self.db_kwargs.pop('database', None)
-        dsn = psycopg2.extensions.make_dsn(*self.db_args, **self.db_kwargs) + " dbname='%s'" % dbname
+
+        # 像 users, password 或其他关键字参数值为字符串，也可能 parse_dsn 失败
+        dsn_kwargs = ""
+        for k, v in self.db_kwargs.items():
+            dsn_kwargs += "{keyword}='{value}' ".format(keyword=k, value=v)
+        dsn_kwargs = dsn_kwargs[:-1]  # 去掉尾部空格
+
+        dsn = psycopg2.extensions.make_dsn(*self.db_args) + dsn_kwargs + " dbname='%s'" % dbname
         return dsn
 
     def _reconnect(self):

--- a/pgdb/pgdb.py
+++ b/pgdb/pgdb.py
@@ -77,9 +77,9 @@ class Connection:
         may_dbname = self.db_kwargs.get('dbname', -1)
         may_database = self.db_kwargs.get('database', -1)
         if (may_dbname != -1) and may_database:  # 若提供了两个数据库名
-            raise ValueError('Name confused: {} or {}?'.format(may_dbname, may_database))
+            raise PgdbError('Name confused: {} or {}?'.format(may_dbname, may_database))
         elif (may_dbname == -1) and (may_database == -1):
-            raise ValueError('Should provide the database name to keyword "database" or "dbname"')
+            raise PgdbError('Should provide the database name to keyword "database" or "dbname"')
         dbname = may_dbname if may_dbname != -1 else may_database
         self.db_kwargs.pop('dbname', None)
         self.db_kwargs.pop('database', None)


### PR DESCRIPTION
实际是 psycopg2.extensions.make_dsn 在调用 psycopg2.extensions.parse_dsn
解析中文失败导致的（不是所有的中文都无法解析，但有一些会失败）